### PR TITLE
Remove man page from c/configure.ac - it's built in the top level dir.

### DIFF
--- a/c/configure.ac
+++ b/c/configure.ac
@@ -39,7 +39,6 @@ AC_ARG_WITH([default-city],
      [AC_DEFINE_UNQUOTED(CITY,"$withval",[The Default City])],
      [AC_DEFINE(CITY,"New_York",[The Default City])])
 
-AC_CONFIG_FILES([hebcal.1])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([tests/Makefile])
 


### PR DESCRIPTION
Maybe this is all irrelevant now with go, but:
In c/, may want to run ./configure at install time, for example to set the city.
This requires running autoreconf first, which however fails because there's no hebcal.1.in in that directory.
Deleted the relevant line in configure.ac.
It's not needed anyway because the man page gets built in the top level.
(Maybe long term it would be wise to move the autoconf stuff to the top level.)